### PR TITLE
Implement base error handling

### DIFF
--- a/warhammer-core/WarhammerCore.Abstract/Models/AppSettings.cs
+++ b/warhammer-core/WarhammerCore.Abstract/Models/AppSettings.cs
@@ -1,0 +1,13 @@
+﻿namespace WarhammerCore.Abstract.Models
+{
+    /// <summary>
+    /// Application settings taken from appsettings.json
+    /// </summary>
+    public class AppSettings
+    {
+        /// <summary>
+        /// Whether the application is ran by the developer and the error handlers can give more sensitive information.
+        /// </summary>
+        public bool IsDevelopmentModeOn { get; set; }
+    }
+}

--- a/warhammer-core/WarhammerCore.WebApi/Controllers/ProfessionController.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Controllers/ProfessionController.cs
@@ -4,7 +4,9 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using WarhammerCore.Abstract.Interfaces;
 using WarhammerCore.Abstract.Models;
+using WarhammerCore.WebApi.Models.Enums;
 using WarhammerCore.WebApi.Models.Request;
+using WarhammerCore.WebApi.Models.Response;
 
 namespace WarhammerCore.WebApi.Controllers
 {
@@ -27,7 +29,11 @@ namespace WarhammerCore.WebApi.Controllers
         [HttpPost]
         public async Task<ActionResult<Profession>> GetProfession(GetProfessionRequest request)
         {
-            return await _professionService.GetProfessionAsync(request.ProfessionId);
+            Profession profession = await _professionService.GetProfessionAsync(request.ProfessionId);
+
+            if (profession == null) return NotFound(new ErrorResponse(ErrorCode.ProfessionNotFound));
+
+            return Ok(profession);
         }
     }
 }

--- a/warhammer-core/WarhammerCore.WebApi/Exceptions/ControllerException.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Exceptions/ControllerException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Net;
+using WarhammerCore.WebApi.Models.Enums;
+
+namespace WarhammerCore.WebApi.Exceptions
+{
+    /// <summary>
+    /// Exception happened in the WebAPI controllers.
+    /// </summary>
+    public class ControllerException : Exception
+    {
+        public ErrorCode ErrorCode { get; }
+        public HttpStatusCode StatusCode { get; } = HttpStatusCode.BadRequest;
+
+        public ControllerException(ErrorCode errorCode, string message, HttpStatusCode statusCode) : base(message)
+        {
+            ErrorCode = errorCode;
+            StatusCode = statusCode;
+        }
+    }
+}

--- a/warhammer-core/WarhammerCore.WebApi/Exceptions/RequestValidationException.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Exceptions/RequestValidationException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using WarhammerCore.WebApi.Models.Errors;
+
+namespace WarhammerCore.WebApi.Middleware
+{
+    /// <summary>
+    /// Fluent validation error. Request parameter was invalid.
+    /// </summary>
+    public class RequestValidationException : Exception
+    {
+        /// <summary>
+        /// List of properties that were invalid.
+        /// </summary>
+        public List<RequestValidationError> Errors { get; }
+
+        public RequestValidationException(IEnumerable<RequestValidationError> errors)
+        {
+            Errors = errors?.ToList() ?? throw new ArgumentNullException(nameof(errors));
+        }
+    }
+}

--- a/warhammer-core/WarhammerCore.WebApi/Extensions/AppServicesExtension.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Extensions/AppServicesExtension.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using System;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using WarhammerCore.Abstract.Interfaces;
+using WarhammerCore.Abstract.Models;
 using WarhammerCore.Business;
 using WarhammerCore.Data;
 
@@ -11,12 +10,40 @@ namespace WarhammerCore.WebApi.Extensions
 {
     public static class AppServicesExtension
     {
+        /// <summary>
+        /// Include services with Dependency Injection.
+        /// </summary>
         public static IServiceCollection AddAppServices(this IServiceCollection serviceCollection)
         {
             serviceCollection.AddScoped<IProfessionService, ProfessionService>();
             serviceCollection.AddScoped<IDataRepo, DataRepo>();
 
+            serviceCollection.AddServiceOptions<AppSettings>("AppSettings");
+
             return serviceCollection;
+        }
+
+        /// <summary>
+        /// Go through all the configurations and find the section we are looking for. Assign the values to the model.
+        /// </summary>
+        /// <typeparam name="TOptions">Model class for the settings section.</typeparam>
+        /// <param name="sectionName">Section name, for example in appsettings.json</param>
+        /// <returns></returns>
+        private static IServiceCollection AddServiceOptions<TOptions>(this IServiceCollection services, string sectionName) where TOptions : class
+        {
+            return services.AddSingleton(sp =>
+            {
+                IEnumerable<IConfiguration> configurations = sp.GetRequiredService<IEnumerable<IConfiguration>>();
+                foreach (var configuration in configurations)
+                {
+                    var section = configuration.GetSection(sectionName);
+                    if (!section.Exists()) continue;
+
+                    return section.Get<TOptions>();
+                }
+
+                return default;
+            });
         }
     }
 }

--- a/warhammer-core/WarhammerCore.WebApi/Middleware/ErrorBuilder.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Middleware/ErrorBuilder.cs
@@ -1,0 +1,127 @@
+﻿using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using WarhammerCore.Abstract.Models;
+using WarhammerCore.WebApi.Models.Response;
+
+namespace WarhammerCore.WebApi.Middleware
+{
+    /// <summary>
+    /// Error builder for the responses. Can be chained.
+    /// </summary>
+    public class ErrorBuilder
+    {
+        private readonly Exception exception;
+        private readonly HttpContext context;
+        private readonly Dictionary<string, object> data;
+        private string errorCode, description;
+        private int httpCode;
+        private readonly AppSettings appSettings;
+
+        public ErrorBuilder(HttpContext context, string requestBody, Exception ex, AppSettings appSettings)
+        {
+            this.context = context ?? throw new ArgumentNullException(nameof(context));
+            this.appSettings = appSettings;
+            exception = ex;
+            data = new Dictionary<string, object>();
+            httpCode = StatusCodes.Status500InternalServerError;
+            errorCode = "InternalServerError";
+
+            if (!string.IsNullOrEmpty(requestBody)) AddData("RequestBody", requestBody);
+        }
+
+        /// <summary>
+        /// Build response and send it.
+        /// </summary>
+        /// <returns></returns>
+        public async Task BuildAndSendAsync()
+        {
+            string result = Build();
+
+            context.Response.ContentType = "application/json";
+            context.Response.StatusCode = httpCode;
+
+            await context.Response.WriteAsync(result);
+        }
+
+        /// <summary>
+        /// Build response model with the exception information.
+        /// </summary>
+        public string Build()
+        {
+            ErrorResponse response;
+
+            if (appSettings.IsDevelopmentModeOn)
+            {
+                response = new ErrorResponse(errorCode, $"{description}, \n {exception.Message}");
+
+                foreach (var point in data)
+                    response.AddData(point.Key, point.Value);
+            }
+            else
+            {
+                response = new ErrorResponse(errorCode, description);
+            }
+            return JsonConvert.SerializeObject(response);
+        }
+
+        #region Chain Methods
+
+        /// <summary>
+        /// Set HTTP status code for response.
+        /// </summary>
+        /// <param name="httpCode">HTTP status code.</param>
+        /// <returns>Error builder instance so we can chain methods.</returns>
+        public ErrorBuilder SetHttpCode(int httpCode)
+        {
+            this.httpCode = httpCode;
+            return this;
+        }
+
+        /// <summary>
+        /// Set HTTP status code for response.
+        /// </summary>
+        /// <param name="httpCode">HTTP status code.</param>
+        /// <returns>Error builder instance so we can chain methods.</returns>
+        public ErrorBuilder SetHttpCode(HttpStatusCode httpCode) => SetHttpCode((int)httpCode);
+
+        /// <summary>
+        /// Set error code value.
+        /// </summary>
+        /// <param name="errorCode">Error code (enum or string value).</param>
+        /// <returns>Error builder instance so we can chain methods.</returns>
+        public ErrorBuilder SetErrorCode(object errorCode)
+        {
+            this.errorCode = errorCode.ToString();
+            return this;
+        }
+
+        /// <summary>
+        /// Set custom description.
+        /// </summary>
+        /// <param name="description"></param>
+        /// <returns>Error builder instance so we can chain methods.</returns>
+        public ErrorBuilder SetDescription(string description)
+        {
+            this.description = description;
+            return this;
+        }
+
+        /// <summary>
+        /// Add information to data list.
+        /// </summary>
+        /// <param name="key">Data key.</param>
+        /// <param name="value">Data value.</param>
+        /// <returns>Error builder instance so we can chain methods.</returns>
+        public ErrorBuilder AddData(string key, object value)
+        {
+            data.Add(key, value);
+            return this;
+        }
+
+        #endregion Chain Methods
+    }
+}

--- a/warhammer-core/WarhammerCore.WebApi/Middleware/ErrorBuilder.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Middleware/ErrorBuilder.cs
@@ -56,7 +56,7 @@ namespace WarhammerCore.WebApi.Middleware
 
             if (appSettings.IsDevelopmentModeOn)
             {
-                response = new ErrorResponse(errorCode, $"{description}, \n {exception.Message}");
+                response = new ErrorResponse(errorCode, $"Description: {description}. Exception message: {exception.Message}");
 
                 foreach (var point in data)
                     response.AddData(point.Key, point.Value);

--- a/warhammer-core/WarhammerCore.WebApi/Middleware/ErrorHandlingMiddleware.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Middleware/ErrorHandlingMiddleware.cs
@@ -1,0 +1,123 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using WarhammerCore.Abstract.Models;
+using WarhammerCore.WebApi.Exceptions;
+using WarhammerCore.WebApi.Middleware;
+
+namespace HostApp.WebApi.Middlewares
+{
+    /// <summary>
+    /// Middleware that catches the errors and returns a commonly structed error.
+    /// </summary>
+    public class ErrorHandlingMiddleware
+    {
+        private readonly RequestDelegate next;
+
+        public ErrorHandlingMiddleware(RequestDelegate next)
+        {
+            this.next = next;
+        }
+
+        /// <summary>
+        /// Regular invoke method.
+        /// Read the request body (request body is a stream).
+        /// </summary>
+        public async Task Invoke(HttpContext context, AppSettings appSettings)
+        {
+            string requestBody = string.Empty;
+
+            try
+            {
+                context.Request.EnableBuffering();
+                requestBody = await ReadRequestBodyAsync(context);
+                await next(context);
+            }
+            catch (Exception ex)
+            {
+                await HandleExceptionAsync(context, requestBody, ex, appSettings);
+            }
+        }
+
+        /// <summary>
+        /// Read request body stream.
+        /// </summary>
+        private static async Task<string> ReadRequestBodyAsync(HttpContext context)
+        {
+            string requestBody = string.Empty;
+
+            if (context.Request.Body?.CanRead == true)
+            {
+                var reader = await context.Request.BodyReader.ReadAsync();
+                context.Request.Body.Position = 0;
+                var buffer = reader.Buffer;
+                requestBody = Encoding.UTF8.GetString(buffer.FirstSpan);
+                context.Request.Body.Position = 0;
+            }
+
+            return requestBody;
+        }
+
+        /// <summary>
+        /// Handle exception and build response for it.
+        /// </summary>
+        /// <param name="context">HTTP context.</param>
+        /// <param name="requestBody">Request body content.</param>
+        /// <param name="ex">Exception information.</param>
+        private static Task HandleExceptionAsync(HttpContext context, string requestBody, Exception ex, AppSettings appSettings)
+        {
+            ErrorBuilder errorBuilder = new ErrorBuilder(context, requestBody, ex, appSettings);
+
+            if (ex is ControllerException controllerEx) return BuildAndSendAsync(controllerEx, errorBuilder);
+            if (ex is RequestValidationException validationEx) return BuildAndSendAsync(validationEx, errorBuilder);
+
+            return errorBuilder.BuildAndSendAsync();
+        }
+
+        /// <summary>
+        /// Build response for <see cref="ControllerException"/>.
+        /// </summary>
+        /// <param name="ex">Exception information about an error that happened in the WebApi project.</param>
+        private static Task BuildAndSendAsync(ControllerException ex, ErrorBuilder errorBuilder)
+        {
+            return errorBuilder
+                    .SetHttpCode(ex.StatusCode)
+                    .SetErrorCode(ex.ErrorCode)
+                    .BuildAndSendAsync();
+        }
+
+        /// <summary>
+        /// Build response for <see cref="RequestValidationException"/>.
+        /// </summary>
+        /// <param name="ex">Exception information about an error that happened in the WebApi project.</param>
+        private static Task BuildAndSendAsync(RequestValidationException ex, ErrorBuilder errorBuilder)
+        {
+            foreach (var error in ex.Errors)
+                errorBuilder.AddData($"Invalid property: {error.PropertyName}", string.Join("; ", error.Messages));
+
+            return errorBuilder
+                .SetDescription("Invalid request parameters")
+                .SetHttpCode(HttpStatusCode.BadRequest)
+                .SetErrorCode("RequestValidationError")
+                .BuildAndSendAsync();
+        }
+    }
+
+    /// <summary>
+    /// Error handling extension.
+    /// </summary>
+    public static class ErrorHandlingMiddlewareExtension
+    {
+        /// <summary>
+        /// Use error handling extension, to provide JSON response in case of errors.
+        /// </summary>
+        public static IApplicationBuilder UseErrorHandling(this IApplicationBuilder app)
+        {
+            app.UseMiddleware<ErrorHandlingMiddleware>();
+            return app;
+        }
+    }
+}

--- a/warhammer-core/WarhammerCore.WebApi/Models/Enums/ErrorCode.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Models/Enums/ErrorCode.cs
@@ -1,0 +1,14 @@
+﻿
+namespace WarhammerCore.WebApi.Models.Enums
+{
+    /// <summary>
+    /// Contains known error codes that are returned by the controllers.
+    /// </summary>
+    public enum ErrorCode
+    {
+        /// <summary>
+        /// User tried to call GetProfession with an unknown ID.
+        /// </summary>
+        ProfessionNotFound
+    }
+}

--- a/warhammer-core/WarhammerCore.WebApi/Models/Errors/RequestValidationError.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Models/Errors/RequestValidationError.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WarhammerCore.WebApi.Models.Errors
+{
+    /// <summary>
+    /// Fluent validation parameter error.
+    /// </summary>
+    public class RequestValidationError
+    {
+        public string PropertyName { get; }
+        public List<string> Messages { get; }
+
+        public RequestValidationError(string propertyName, IEnumerable<string> messages)
+        {
+            if (string.IsNullOrEmpty(propertyName)) throw new ArgumentException("Value cannot be null or empty", nameof(propertyName));
+
+            PropertyName = propertyName;
+            Messages = messages?.ToList() ?? throw new ArgumentNullException(nameof(messages));
+        }
+    }
+}

--- a/warhammer-core/WarhammerCore.WebApi/Models/Response/ErrorResponse.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Models/Response/ErrorResponse.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using WarhammerCore.WebApi.Models.Enums;
+
+namespace WarhammerCore.WebApi.Models.Response
+{
+    public class ErrorResponse
+    {
+        public string ErrorCode { get; }
+        public string Description { get; }
+
+        /// <summary>
+        /// Helpful information for the developer. Not meant to be shown on the production.
+        /// </summary>
+        public Dictionary<string, object> Data { get; }
+
+        public ErrorResponse(string errorCode) : this(errorCode, null)
+        {
+        }
+
+        public ErrorResponse(ErrorCode errorCode) : this(errorCode.ToString(), null)
+        {
+        }
+
+        public ErrorResponse(string errorCode, string description)
+        {
+            ErrorCode = errorCode;
+            Description = description;
+            Data = new Dictionary<string, object>();
+        }
+
+        /// <summary>
+        /// Add information for the developers. Don't show this on the production.
+        /// </summary>
+        public ErrorResponse AddData(string key, object value)
+        {
+            Data.Add(key, value);
+            return this;
+        }
+    }
+}

--- a/warhammer-core/WarhammerCore.WebApi/Startup.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Startup.cs
@@ -22,6 +22,7 @@ namespace WarhammerCore.WebApi
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers();
+            services.AddMvc(options => options.Filters.Add<ValidationFilter>(int.MinValue)).AddFluentValidation(config => config.RegisterValidatorsFromAssemblyContaining<Startup>());
 
             services.AddControllersWithViews();
             services.AddDbContext<WarhammerDbContext>(options => options.UseSqlServer(Configuration.GetConnectionString("SqlServer")));

--- a/warhammer-core/WarhammerCore.WebApi/Startup.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Startup.cs
@@ -1,3 +1,4 @@
+using HostApp.WebApi.Middlewares;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
@@ -6,6 +7,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using WarhammerCore.Data.Models;
 using WarhammerCore.WebApi.Extensions;
+using FluentValidation.AspNetCore;
+using WarhammerCore.WebApi.Validation;
 
 namespace WarhammerCore.WebApi
 {
@@ -46,6 +49,8 @@ namespace WarhammerCore.WebApi
             app.UseRouting();
 
             app.UseAuthorization();
+
+            app.UseErrorHandling();
 
             app.UseEndpoints(endpoints =>
             {

--- a/warhammer-core/WarhammerCore.WebApi/Validation/BaseAbstractValidator.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Validation/BaseAbstractValidator.cs
@@ -1,0 +1,26 @@
+﻿using FluentValidation;
+using System;
+using System.Linq.Expressions;
+
+namespace WarhammerCore.WebApi.Validation
+{
+    /// <summary>
+    /// Base class for the validators. Contains common logic and common tests for the parameters validation.
+    /// </summary>
+    /// <typeparam name="T">Model class that will be validated.</typeparam>
+    public abstract class BaseAbstractValidator<T> : AbstractValidator<T> where T : class
+    {
+        /// <summary>
+        /// Create error messages based on the condition that has failed.
+        /// </summary>
+        /// <typeparam name="T2">Result of the <see cref="parameter"/> lambda expression.</typeparam>
+        /// <param name="parameter">Lambda expression that has a test for the parameter.</param>
+        /// <returns>String error message for the expression result.</returns>
+        public IRuleBuilderOptions<T, T2> RuleForEmptyParameter<T2>(Expression<Func<T, T2>> parameter)
+        {
+            return RuleFor(parameter)
+                .NotNull().WithMessage($"{nameof(parameter)} must have a value.")
+                .NotEmpty().WithMessage($"{nameof(parameter)} must have a value.");
+        }
+    }
+}

--- a/warhammer-core/WarhammerCore.WebApi/Validation/GetProfessionRequestValidator.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Validation/GetProfessionRequestValidator.cs
@@ -1,0 +1,18 @@
+﻿using WarhammerCore.WebApi.Models.Request;
+
+namespace WarhammerCore.WebApi.Validation
+{
+    /// <summary>
+    /// Validate request model for the Profession/GetProfession in <see cref="ProfessionController"/>
+    /// </summary>
+    public class GetProfessionRequestValidator : BaseAbstractValidator<GetProfessionRequest>
+    {
+        /// <summary>
+        /// Parameter cannot be null or empty.
+        /// </summary>
+        public GetProfessionRequestValidator()
+        {
+            RuleForEmptyParameter(x => x.ProfessionId);
+        }
+    }
+}

--- a/warhammer-core/WarhammerCore.WebApi/Validation/ValidationFilter.cs
+++ b/warhammer-core/WarhammerCore.WebApi/Validation/ValidationFilter.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Mvc.Filters;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using WarhammerCore.WebApi.Middleware;
+using WarhammerCore.WebApi.Models.Errors;
+
+namespace WarhammerCore.WebApi.Validation
+{
+    /// <summary>
+    /// Validation filter that is set in <see cref="Startup"/> to be the first one ran (for fluent validation).
+    /// </summary>
+    public class ValidationFilter : IAsyncActionFilter
+    {
+        /// <summary>
+        /// Ran before action is passed to the controller. Check for request validation errors (fluent validation).
+        /// </summary>
+        public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        {
+            if (!context.ModelState.IsValid)
+            {
+                var invalidProperties = context.ModelState.Where(x => x.Value.Errors.Count > 0);
+
+                IEnumerable<RequestValidationError> errors = invalidProperties.Select(x => new RequestValidationError(x.Key, x.Value.Errors.Select(y => y.ErrorMessage)));
+
+                throw new RequestValidationException(errors);
+            }
+
+            await next();
+        }
+    }
+}

--- a/warhammer-core/WarhammerCore.WebApi/WarhammerCore.WebApi.csproj
+++ b/warhammer-core/WarhammerCore.WebApi/WarhammerCore.WebApi.csproj
@@ -22,6 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>
 

--- a/warhammer-core/WarhammerCore.WebApi/WarhammerCore.WebApi.csproj
+++ b/warhammer-core/WarhammerCore.WebApi/WarhammerCore.WebApi.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
+    <PackageReference Include="FluentValidation" Version="9.3.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="9.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>

--- a/warhammer-core/WarhammerCore.WebApi/appsettings.json
+++ b/warhammer-core/WarhammerCore.WebApi/appsettings.json
@@ -6,5 +6,8 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "AppSettings": {
+    "IsDevelopmentModeOn":  false
+  }
 }

--- a/warhammer-core/WarhammerCore.WebApi/appsettings.json
+++ b/warhammer-core/WarhammerCore.WebApi/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "AppSettings": {
-    "IsDevelopmentModeOn":  false
+    "IsDevelopmentModeOn":  true
   }
 }


### PR DESCRIPTION
### **New**:
- implemented Fluent Validation for the request parameters validation. Request parameters are now checked before they are passed into the controllers. That way we don't have to create guard clauses in the controllers themselves. We can add new rules by simply creating a class that extends `BaseAbstractValidator` and add our own rules or use existing ones. For example, `GetProfessionRequestValidator` checks for null/empty values. Like this:
```
public GetProfessionRequestValidator()
{
      RuleForEmptyParameter(x => x.ProfessionId);
}
```
- implemented middleware for error handling. Exceptions are now caught by this middleware and errors are returned in a generic format. Different information is returned based on the development/production mode. For example:
Development:
![development](https://user-images.githubusercontent.com/43864376/103175440-55506f00-486a-11eb-82fc-955ce3bbe374.png)
Production:
![production](https://user-images.githubusercontent.com/43864376/103175438-541f4200-486a-11eb-942c-a3475be81e23.png)

- implemented `AppSettings` class taken from the **AppSettings** section in the `appsettings.json`. We can implement more sections as models by using the `AddServiceOptions` method in `AppServicesExtension`.
- errors can be built with the `ErrorBuilder`. We can chain builder methods. This is very useful in the `BuildAndSendAsync` methods in middleware to easily create responses based on the exception type